### PR TITLE
Fix: Only respond to initialized bot accounts

### DIFF
--- a/modules/self_contained/ai_chat/__init__.py
+++ b/modules/self_contained/ai_chat/__init__.py
@@ -135,6 +135,7 @@ async def chat_gpt(
 
     at_result: At = AtResult.result  # type: ignore
     at_qq_num = at_result.target
+    # 防止At任意对象都能触发，这里At对象只能为已经初始化的bot
     if at_qq_num not in account_controller.initialized_bot_list:
         return
     

--- a/modules/self_contained/ai_chat/core/manager.py
+++ b/modules/self_contained/ai_chat/core/manager.py
@@ -77,6 +77,12 @@ class Conversation:
         # 要排除 system 和 tool 的消息，然后计算 user 和 assistant 的消息数量，然后除以 2
         return len([msg for msg in self.history if msg["role"] in ["user", "assistant"]]) // 2
 
+    def _maybe_add_time_message(self):
+        """根据对话轮次决定是否添加时间信息"""
+        current_round = self.get_round()
+        if current_round > 0 and current_round % 10 == 0:
+            self.history.append(self._get_time_message())
+
     async def process_message(self, user_input: str, use_tool: bool = False) -> AsyncGenerator[str, None]:
         """处理用户消息,包括历史记录管理和工具调用"""
         try:
@@ -94,10 +100,8 @@ class Conversation:
                     self.history.pop(i)
                     break
             
-            # 每10轮对话添加一次时间信息
-            current_round = self.get_round()
-            if current_round > 0 and current_round % 10 == 0:
-                self.history.append(self._get_time_message())
+            # 添加时间信息(如果需要)
+            self._maybe_add_time_message()
 
             # 构造传入 AI 模型的消息列表
             preset_messages = [{"role": "system", "content": self.preset}] if self.preset else []

--- a/modules/self_contained/ai_chat/metadata.json
+++ b/modules/self_contained/ai_chat/metadata.json
@@ -9,7 +9,7 @@
   "description": "AI Chat",
   "usage": [
     "指令:",
-    "-chat [文字]",
+    "@bot 消息内容",
     "支持参数:",
     "-n / -new - 开启新对话",
     "-t / -text - 以文本模式回复(默认图片回复)",
@@ -19,7 +19,11 @@
     "--reload-cfg - 重载配置(限BOT管理员)"
   ],
   "example": [
-    "-chat 你好"
+    "@bot 你好",
+    "@bot -n -p cat_girl 你好",
+    "@bot -n 你好",
+    "@bot --tool 讲讲关于CloseAI的消息",
+    "@bot --show-preset"
   ],
   "default_switch": false,
   "default_notice": true


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 AI 聊天模块，使用 at 命令来触发机器人，并每 10 轮对话添加一个时间消息。

新功能：
- 使用 at 命令来触发机器人，而不是 -chat 命令。
- 每 10 轮对话添加一个时间消息。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 AI 聊天模块，使用 at 命令触发机器人，并在每 10 轮对话后添加时间消息。

新功能：
- 使用 at 命令而不是 -chat 命令来触发机器人。
- 每 10 轮对话添加一个时间消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the AI Chat module to use the at command to trigger the bot and add a time message every 10 conversation rounds.

New Features:
- Trigger the bot using the at command instead of the -chat command.
- Add a time message every 10 conversation rounds.

</details>

</details>