### PR TITLE
Add --show-tokens option to display token usage

### DIFF
--- a/modules/self_contained/ai_chat/__init__.py
+++ b/modules/self_contained/ai_chat/__init__.py
@@ -101,7 +101,6 @@ async def init():
         listening_events=[GroupMessage],
         inline_dispatchers=[
             Twilight([
-                # FullMatch("-chat"),
                 ElementMatch(At, optional=False).space(SpacePolicy.PRESERVE) @ "AtResult",
                 ArgumentMatch("-n", "-new", action="store_true", optional=True) @ "new_thread",
                 ArgumentMatch("-t", "-text", action="store_true", optional=True) @ "text",

--- a/modules/self_contained/ai_chat/metadata.json
+++ b/modules/self_contained/ai_chat/metadata.json
@@ -12,18 +12,21 @@
     "@bot 消息内容",
     "支持参数:",
     "-n / -new - 开启新对话",
-    "-t / -text - 以文本模式回复(默认图片回复)",
-    "-T / --tool - 自动使用工具(如网络搜索/天气等)",
+    "-P / --pic - 以图片模式回复(默认文本回复)",
+    "-t / --tool - 自动使用工具(如网络搜索/天气等)",
     "-p / -preset - 设定预设",
     "--show-preset - 显示预设",
+    "--show-tokens - 输出当前花费的Token数量",
     "--reload-cfg - 重载配置(限BOT管理员)"
   ],
   "example": [
     "@bot 你好",
     "@bot -n -p cat_girl 你好",
-    "@bot -n 你好",
+    "@bot -n -P 生成一段Python代码",
     "@bot --tool 讲讲关于CloseAI的消息",
-    "@bot --show-preset"
+    "@bot --show-preset",
+    "@bot --show-tokens",
+    "@bot --reload-cfg"
   ],
   "default_switch": false,
   "default_notice": true


### PR DESCRIPTION
## Sourcery 总结

新功能：
- 在 `/chat` 命令中添加了 `--show-tokens` 参数，可以选择在响应中显示 token 使用情况和当前轮数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Added a `--show-tokens` argument to the `/chat` command to optionally display the token usage and current round number in the response.

</details>