### PR TITLE
Add clear history command and refactor new thread command

### DIFF
--- a/modules/self_contained/ai_chat/__init__.py
+++ b/modules/self_contained/ai_chat/__init__.py
@@ -232,21 +232,6 @@ async def ai_chat(
             quote=source
         )
 
-    if preset.matched:
-        # 群聊预设暂不鉴权
-        preset_str = preset.result.display.strip()
-        g_manager.set_preset(
-            group_id_str,
-            member_id_str,
-            preset_dict[preset_str]["content"] if preset_str in preset_dict \
-                else (preset_str or preset_dict["umaru"]["content"])
-        )
-        await app.send_group_message(
-            group,
-            MessageChain(f"已设置预设：{preset_str}{'(内置预设)' if preset_str in preset_dict else '(自定义预设)'}"),
-            quote=source
-        )
-
     if new_thread.matched:
         # 先获取群聊模式，如果是shared就鉴权，只能是群管理员以上才能清除上下文并开始新对话
         cur_group_mode = g_manager.get_group_mode(group_id_str)
@@ -265,12 +250,23 @@ async def ai_chat(
             quote=source
         )
 
-    if not content:
-        return await app.send_group_message(
+    if preset.matched:
+        # 群聊预设暂不鉴权
+        preset_str = preset.result.display.strip()
+        g_manager.set_preset(
+            group_id_str,
+            member_id_str,
+            preset_dict[preset_str]["content"] if preset_str in preset_dict \
+                else (preset_str or preset_dict["umaru"]["content"])
+        )
+        await app.send_group_message(
             group,
-            MessageChain("你好像什么也没说哦(｡･∀･)ﾉﾞ"),
+            MessageChain(f"已设置预设：{preset_str}{'(内置预设)' if preset_str in preset_dict else '(自定义预设)'}"),
             quote=source
         )
+
+    if not content:
+        return
     response = await g_manager.send_message(group_id_str, member_id_str, member.name, content, tool.matched)
     if not pic.matched:
         return await app.send_group_message(

--- a/modules/self_contained/ai_chat/__init__.py
+++ b/modules/self_contained/ai_chat/__init__.py
@@ -125,6 +125,8 @@ async def init():
                     optional=True, type=bool, default=False
                 ) @ "show_tokens",
                 ArgumentMatch("--reload-cfg", action="store_true", optional=True) @ "reload_cfg",
+                # -c --clear，清除对话历史
+                ArgumentMatch("-c", "--clear", action="store_true", optional=True) @ "clear_history",
                 WildcardMatch().flags(re.DOTALL) @ "content",
             ])
         ],
@@ -151,7 +153,8 @@ async def ai_chat(
         content: RegexResult,
         show_preset: ArgResult,
         show_tokens: ArgResult,
-        reload_cfg: ArgResult
+        reload_cfg: ArgResult,
+        clear_history: ArgResult
 ):
     """
     修改默认为文字响应，主要考量：
@@ -262,6 +265,24 @@ async def ai_chat(
         await app.send_group_message(
             group,
             MessageChain(f"已设置预设：{preset_str}{'(内置预设)' if preset_str in preset_dict else '(自定义预设)'}"),
+            quote=source
+        )
+    
+    if clear_history.matched:
+        # 先获取群聊模式，如果是shared就鉴权，只能是群管理员以上才能清除上下文
+        cur_group_mode = g_manager.get_group_mode(group_id_str)
+        if cur_group_mode == ConversationManager.GroupMode.SHARED:
+            group_perm = await Permission.get_user_perm_byID(group.id, member.id)
+            if group_perm < Permission.GroupAdmin:
+                return await app.send_group_message(
+                    group,
+                    MessageChain("当前对话为群共享模式，只有群管理员才能执行这个操作"),
+                    quote=source
+                )
+        g_manager.clear_memory(group_id_str, member_id_str)
+        await app.send_group_message(
+            group,
+            MessageChain("已清除对话历史"),
             quote=source
         )
 

--- a/modules/self_contained/ai_chat/metadata.json
+++ b/modules/self_contained/ai_chat/metadata.json
@@ -15,6 +15,7 @@
     "-P / --pic - 以图片模式回复(默认文本回复)",
     "-t / --tool - 自动使用工具(如网络搜索/天气等)",
     "-p / -preset - 设定预设",
+    "-c / --clear - 清除当前对话历史记录",
     "--show-preset - 显示预设",
     "--show-tokens - 输出当前花费的Token数量",
     "--reload-cfg - 重载配置(限BOT管理员)"


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加清晰的历史记录命令行选项和群聊命令。如果群聊处于共享模式，则仅限管理员清除历史记录。

新功能：
- 添加 `-c`/`--clear` 参数以清除对话历史记录并开始新的对话。
- 为群聊添加清除历史记录功能。如果群组模式为共享模式，则只有群组管理员及以上级别的人员才能清除历史记录。如果群组模式不是共享模式，则任何成员都可以清除历史记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a clear history command-line option and group chat command.  If the group chat is in shared mode, restrict clearing history to admins only.

New Features:
- Add a `-c`/`--clear` argument to clear the conversation history and start a new conversation.
- Add a clear history feature for group chats.  If the group mode is shared, only group admins and above can clear the history.  If the group mode is not shared, any member can clear the history

</details>