### PR TITLE
fix(Bf1): 移除EAC状态校验逻辑

### DIFF
--- a/modules/self_contained/bf1_servermanager/__init__.py
+++ b/modules/self_contained/bf1_servermanager/__init__.py
@@ -4373,31 +4373,7 @@ async def add_cloudban(
             action="cloudban",
             info=reason,
         )
-        # 检查是否接入EAC，若没有接入EAC则警告cb无作用
-        server_info = await account_instance.getFullServerDetails(server_gameid)
-        if isinstance(server_info, str):
-            return await app.send_message(
-                group,
-                MessageChain(f"WANING: 校验EAC状态时出错!{server_info}"),
-                quote=source
-            )
-        server_info = server_info["result"]
-        admin_list = [item["personaId"] for item in server_info["rspInfo"]["adminList"]]
-        tvbot_list = await EACUtils().get_22tvbot_list()
-        if not tvbot_list:
-            return await app.send_message(
-                group,
-                MessageChain(f"WANING: 校验EAC状态时出错!获取BOT列表失败"),
-                quote=source
-            )
-        bot_pid_list = {str(bot["personaId"]) for bot in tvbot_list}
-        if not any(admin_id in bot_pid_list for admin_id in admin_list):
-            return await app.send_message(
-                group,
-                MessageChain(f"WANING: 校验EAC状态时出错!服务器未接入EAC,CloudBan is not working!"),
-                quote=source
-            )
-        return
+        return 
     return await app.send_message(group, MessageChain(
         f"执行出错!{result}"
     ), quote=source)


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 移除在战地1服务器管理器中添加云封禁时的 EAC 状态检查逻辑，以解决云封禁功能的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove the EAC status check logic when adding a cloud ban in the Battlefield 1 server manager to resolve issues with cloudban functionality.

</details>