### PR TITLE
feat(Conversation): 添加模型切换功能，支持会话历史和预设保留

### DIFF
--- a/modules/self_contained/ai_chat/core/provider.py
+++ b/modules/self_contained/ai_chat/core/provider.py
@@ -22,13 +22,13 @@ class FileContent:
     """文件内容结构"""
 
     def __init__(
-            self,
-            file_type: FileType,
-            file_bytes: bytes = None,
-            file_path: str = None,
-            file_url: str = None,
-            file_name: str = None,
-            mime_type: str = None,
+        self,
+        file_type: FileType,
+        file_bytes: bytes = None,
+        file_path: str = None,
+        file_url: str = None,
+        file_name: str = None,
+        mime_type: str = None,
     ):
         self.file_type = file_type
         self.file_bytes = file_bytes
@@ -93,11 +93,11 @@ class BaseAIProvider(ABC):
 
     @abstractmethod
     async def ask(
-            self,
-            messages: List[Dict[str, Any]],
-            files: List[FileContent] = None,
-            tools: List[Dict[str, Any]] = None,
-            **kwargs,
+        self,
+        messages: List[Dict[str, Any]],
+        files: List[FileContent] = None,
+        tools: List[Dict[str, Any]] = None,
+        **kwargs,
     ) -> AsyncGenerator[Any, None]:
         """
         纯粹的消息接口封装,接收完整的消息列表和工具配置
@@ -169,3 +169,10 @@ class BaseAIProvider(ABC):
             return []
 
         return [f for f in files if self.supports_file_type(f.file_type)]
+
+    def get_available_models(self) -> list[str]:
+        """获取当前提供商可用的模型列表"""
+        # 默认实现返回当前模型
+        if hasattr(self, "model_name") and self.model_name:
+            return [self.model_name]
+        return []

--- a/modules/self_contained/ai_chat/metadata.json
+++ b/modules/self_contained/ai_chat/metadata.json
@@ -16,6 +16,7 @@
     "--no-tool - 禁用工具调用(支持工具调用的模型会默认开启)",
     "-p / -preset - 设定预设",
     "-c / --clear - 清除当前对话历史记录",
+    "-m / --model - 切换模型",
     "--show-preset - 显示预设",
     "--model-info / --info - 显示当前模型信息及状态",
     "--no-vision - 禁用多模态输入",
@@ -28,7 +29,8 @@
     "@bot --tool 讲讲关于CloseAI的消息",
     "@bot --show-preset",
     "@bot --info",
-    "@bot --reload-cfg"
+    "@bot --reload-cfg",
+    "@bot -m deepseek-chat"
   ],
   "default_switch": false,
   "default_notice": true

--- a/modules/self_contained/ai_chat/providers/deepseek.py
+++ b/modules/self_contained/ai_chat/providers/deepseek.py
@@ -27,8 +27,8 @@ class DeepSeekConfig(OpenAICompatibleConfig):
                 max_total_tokens=64000,
                 supports_tool_calls=True,
             )
-            self.models["deepseek-r1"] = ModelConfig(
-                name="deepseek-r1",
+            self.models["deepseek-reasoner"] = ModelConfig(
+                name="deepseek-reasoner",
                 max_tokens=8192,
                 max_total_tokens=64000,
                 supports_tool_calls=True,
@@ -94,3 +94,8 @@ class DeepSeekProvider(OpenAICompatibleProvider):
                     elif item.get("type") == "image_url":
                         total_tokens += 1000
         return int(total_tokens)
+
+    def get_available_models(self) -> list[str]:
+        """获取DeepSeek可用的模型列表"""
+        # 返回配置中支持的模型
+        return list(self.config.models.keys())

--- a/modules/self_contained/ai_chat/providers/openai.py
+++ b/modules/self_contained/ai_chat/providers/openai.py
@@ -112,3 +112,8 @@ class OpenAIProvider(OpenAICompatibleProvider):
                     elif item.get("type") == "image_url":
                         token_count += 1000
         return token_count
+
+    def get_available_models(self) -> list[str]:
+        """获取OpenAI可用的模型列表"""
+        # 返回配置中支持的模型
+        return list(self.config.models.keys())


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增加了切换对话中使用的 AI 模型的功能，同时保留对话历史记录和预设。 这包括获取提供商可用的模型、检查模型兼容性以及更新用户模型偏好设置。

新功能：
- 引入了使用 `--model` 或 `-m` 参数切换对话中使用的 AI 模型的功能。
- 增加了一个新的命令行参数 `--model-info` 或 `--info`，用于显示有关当前 AI 模型的信息，包括当前提供商可用的模型。

测试：
- 增加了测试，以确保新的模型切换功能按预期工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds functionality to switch the AI model used in a conversation, preserving conversation history and presets. This includes fetching available models for a provider, checking model compatibility, and updating user model preferences.

New Features:
- Introduces the ability to switch the AI model used in a conversation using the `--model` or `-m` argument.
- Adds a new command-line argument `--model-info` or `--info` to display information about the current AI model, including available models for the current provider.

Tests:
- Adds tests to ensure the new model switching functionality works as expected.

</details>