### PR TITLE
fix(api): update platoon info retrieval to use active platoon method

### DIFF
--- a/modules/self_contained/bf1_join_request_handle/__init__.py
+++ b/modules/self_contained/bf1_join_request_handle/__init__.py
@@ -130,7 +130,7 @@ async def join_handle(app: Ariadne, event: MemberJoinRequestEvent):
                     server_playing_info_task = api_instance.getServersByPersonaIds(
                         player_pid
                     )
-                    platoon_info_task = api_instance.getPlatoonsByPersonaId(player_pid)
+                    platoon_info_task = api_instance.getActivePlatoon(player_pid)
                     skin_info_task = api_instance.getPresetsByPersonaId(player_pid)
                     gt_id_info_task = gt_get_player_id_by_pid(player_pid)
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 将已弃用的 `getPlatoonsByPersonaId` 方法替换为 `getActivePlatoon`，以检索正确的 platoon 信息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace deprecated getPlatoonsByPersonaId method with getActivePlatoon to retrieve the correct platoon information

</details>