### PR TITLE
Fix invite handler null group case

### DIFF
--- a/modules/required/group_manager/__init__.py
+++ b/modules/required/group_manager/__init__.py
@@ -90,7 +90,7 @@ async def invited_event(app: Ariadne, event: BotInvitedJoinGroupRequestEvent):
             await Permission.require_user_perm(
                 waiter_group.id, waiter_member.id, Permission.GroupAdmin
             )
-            and group.id == waiter_group.id
+            and (group is not None and group.id == waiter_group.id)
             and event_waiter.quote
             and event_waiter.quote.id == bot_message.id
         ):
@@ -100,7 +100,7 @@ async def invited_event(app: Ariadne, event: BotInvitedJoinGroupRequestEvent):
             elif saying == "n":
                 return False, waiter_member.id
             elif saying.startswith("n"):
-                saying.replace("n", "")
+                saying = saying[1:]
                 return False, waiter_member.id
 
     try:


### PR DESCRIPTION
## Summary
- handle missing group correctly in invite waiter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844168567308320ae1ce4eac0129437

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了邀请等待器处理 null group 的情况，并正确地去除了否定回复中开头的 "n"

Bug 修复：
- 在邀请等待器中比较 ID 之前，为 group 添加了 null 检查
- 使用字符串切片来删除开头的 "n"，而不是替换，以正确解析否定回复

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix invite waiter to handle null group case and properly strip the leading 'n' in negative responses

Bug Fixes:
- Add null check for group before comparing IDs in the invite waiter
- Use string slicing to remove the leading “n” instead of replace to correctly parse negative replies

</details>