### PR TITLE
fix(bf1/blaze): resolve SSL protocol keepalive AttributeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,9 +239,28 @@ docstring-code-format = true # 启用 docstring 代码片段格式化
 [dependency-groups]
 dev = [
     "pre-commit>=4.2.0",
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.0.0",
     "ruff>=0.11.13",
 ]
 
 # 配置 Ruff 的 PyUpgrade 功能（Python 版本兼容性优化）
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = true # 保留 `from __future__ import annotations`，避免影响运行时类型检查
+
+# pytest 配置
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-v",
+    "--tb=short",
+    "--strict-markers",
+]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests",
+]

--- a/tests/test_blaze_socket_keepalive.py
+++ b/tests/test_blaze_socket_keepalive.py
@@ -1,0 +1,218 @@
+"""
+pytest测试文件：BlazeSocket keepalive机制修复验证
+
+测试覆盖范围：
+1. _is_writer_valid()方法的各种场景
+2. _cleanup_connection()方法
+3. keepalive()方法在连接异常时的行为
+4. SSL连接状态检查逻辑
+
+使用mock对象进行完全隔离的单元测试，不依赖外部服务。
+
+运行方式：
+- 运行所有测试：uv run pytest tests/test_blaze_socket_keepalive.py
+- 运行详细输出：uv run pytest tests/test_blaze_socket_keepalive.py -v
+- 运行特定测试：uv run pytest tests/test_blaze_socket_keepalive.py::TestBlazeSocketKeepalive::test_is_writer_valid_with_none_writer
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+# 添加项目根目录到路径
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.bf1.blaze.BlazeSocket import BlazeSocket
+
+
+class TestBlazeSocketKeepalive:
+    """BlazeSocket keepalive机制修复的pytest测试类"""
+
+    @pytest.fixture
+    def blaze_socket(self):
+        """创建BlazeSocket实例的fixture"""
+        return BlazeSocket("test.com", 443)
+
+    def test_is_writer_valid_with_none_writer(self, blaze_socket):
+        """测试writer为None时的有效性检查"""
+        blaze_socket.writer = None
+
+        result = blaze_socket._is_writer_valid()
+        assert not result, "writer为None时应返回False"
+
+    def test_is_writer_valid_with_closing_writer(self, blaze_socket):
+        """测试writer正在关闭时的有效性检查"""
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = True
+        blaze_socket.writer = mock_writer
+
+        result = blaze_socket._is_writer_valid()
+        assert not result, "writer正在关闭时应返回False"
+
+    def test_is_writer_valid_with_closing_transport(self, blaze_socket):
+        """测试transport正在关闭时的有效性检查"""
+        mock_transport = Mock()
+        mock_transport.is_closing.return_value = True
+
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = mock_transport
+        blaze_socket.writer = mock_writer
+
+        result = blaze_socket._is_writer_valid()
+        assert not result, "transport正在关闭时应返回False"
+
+    def test_is_writer_valid_with_none_transport(self, blaze_socket):
+        """测试transport为None时的有效性检查"""
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = None
+        blaze_socket.writer = mock_writer
+
+        result = blaze_socket._is_writer_valid()
+        assert not result, "transport为None时应返回False"
+
+    def test_is_writer_valid_with_none_ssl_protocol(self, blaze_socket):
+        """测试SSL协议层为None时的有效性检查"""
+        mock_transport = Mock()
+        mock_transport.is_closing.return_value = False
+        mock_transport._ssl_protocol = None
+
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = mock_transport
+        blaze_socket.writer = mock_writer
+
+        result = blaze_socket._is_writer_valid()
+        assert not result, "SSL协议层为None时应返回False"
+
+    def test_is_writer_valid_with_valid_writer(self, blaze_socket):
+        """测试有效writer的检查"""
+        mock_transport = Mock()
+        mock_transport.is_closing.return_value = False
+        mock_transport._ssl_protocol = Mock()  # 非None的SSL协议层
+
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = mock_transport
+        blaze_socket.writer = mock_writer
+
+        result = blaze_socket._is_writer_valid()
+        assert result, "有效writer应返回True"
+
+    def test_is_writer_valid_without_ssl_protocol_attribute(self, blaze_socket):
+        """测试transport没有_ssl_protocol属性时的检查（非SSL连接）"""
+        mock_transport = Mock()
+        mock_transport.is_closing.return_value = False
+        # 删除_ssl_protocol属性，模拟非SSL连接
+        if hasattr(mock_transport, "_ssl_protocol"):
+            delattr(mock_transport, "_ssl_protocol")
+
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = mock_transport
+        blaze_socket.writer = mock_writer
+
+        result = blaze_socket._is_writer_valid()
+        assert result, "没有SSL协议层属性的有效writer应返回True"
+
+    def test_cleanup_connection(self, blaze_socket):
+        """测试连接清理方法"""
+        blaze_socket.writer = Mock()
+        blaze_socket.reader = Mock()
+
+        blaze_socket._cleanup_connection()
+
+        assert blaze_socket.writer is None, "清理连接后writer应为None"
+        assert blaze_socket.reader is None, "清理连接后reader应为None"
+
+    @pytest.mark.asyncio
+    async def test_keepalive_with_invalid_writer(self, blaze_socket):
+        """测试keepalive在writer无效时的行为"""
+        blaze_socket.connect = True
+        blaze_socket.writer = None  # 无效的writer
+
+        # 使用patch来模拟asyncio.sleep，避免实际等待
+        with patch("asyncio.sleep") as mock_sleep:
+            # 设置sleep被调用后立即返回
+            mock_sleep.return_value = AsyncMock()
+
+            # 运行keepalive，它应该检测到writer无效并退出
+            await blaze_socket.keepalive()
+
+            # 验证结果
+            assert not blaze_socket.connect, (
+                "keepalive在writer无效时应设置connect=False"
+            )
+            assert blaze_socket.writer is None, "writer应保持为None"
+            assert blaze_socket.reader is None, "reader应被清理为None"
+            mock_sleep.assert_called_once_with(60)
+
+    @pytest.mark.asyncio
+    async def test_keepalive_with_write_exception(self, blaze_socket):
+        """测试keepalive在写入异常时的行为"""
+        blaze_socket.connect = True
+
+        # 模拟有效的writer但写入时抛出异常
+        mock_transport = Mock()
+        mock_transport.is_closing.return_value = False
+        mock_transport._ssl_protocol = Mock()
+
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = mock_transport
+        mock_writer.write.side_effect = Exception("模拟写入异常")
+        mock_writer.drain = AsyncMock()
+
+        blaze_socket.writer = mock_writer
+
+        with patch("asyncio.sleep") as mock_sleep:
+            mock_sleep.return_value = AsyncMock()
+
+            # 运行keepalive，它应该捕获异常并清理连接
+            await blaze_socket.keepalive()
+
+            # 验证结果
+            assert not blaze_socket.connect, "keepalive在写入异常时应设置connect=False"
+            assert blaze_socket.writer is None, "writer应被清理为None"
+            assert blaze_socket.reader is None, "reader应被清理为None"
+
+    @pytest.mark.asyncio
+    async def test_keepalive_normal_operation(self, blaze_socket):
+        """测试keepalive正常运行时的行为"""
+        blaze_socket.connect = True
+
+        # 模拟有效的writer
+        mock_transport = Mock()
+        mock_transport.is_closing.return_value = False
+        mock_transport._ssl_protocol = Mock()
+
+        mock_writer = Mock()
+        mock_writer.is_closing.return_value = False
+        mock_writer.transport = mock_transport
+        mock_writer.drain = AsyncMock()
+
+        blaze_socket.writer = mock_writer
+
+        # 控制循环次数
+        call_count = 0
+
+        async def mock_sleep(duration):  # noqa: F401
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:  # 运行两次后停止
+                blaze_socket.connect = False
+
+        with patch("asyncio.sleep", side_effect=mock_sleep):
+            await blaze_socket.keepalive()
+
+            # 验证writer.write被调用
+            assert mock_writer.write.call_count >= 1, "keepalive应该调用writer.write"
+            assert mock_writer.drain.call_count >= 1, "keepalive应该调用writer.drain"
+
+
+if __name__ == "__main__":
+    # 支持直接运行测试文件
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -313,6 +313,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -381,6 +383,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 
@@ -1167,6 +1171,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "jieba"
 version = "0.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1878,6 +1891,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2154,6 +2176,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add comprehensive writer validity checks in _is_writer_valid()
- Implement proper connection cleanup in _cleanup_connection()
- Enhance keepalive method with SSL connection state validation
- Improve error handling in receive_data() and request() methods
- Add pytest test suite with 11 comprehensive test cases
- Use loguru.exception for better error tracking

Fixes: 'NoneType' object has no attribute '_write_appdata' error that occurred when SSL protocol layer was None during keepalive operations.

The fix ensures robust connection state management and prevents resource leaks in BlazeSocket connections.

Test coverage:
- Writer validity checks (7 scenarios)
- Connection cleanup functionality
- Keepalive behavior under various failure conditions
- SSL connection state validation logic