### PR TITLE
feat(minecraft): 优化WebSocket服务器添加验证逻辑

### DIFF
--- a/modules/self_contained/minicraft_info/database.py
+++ b/modules/self_contained/minicraft_info/database.py
@@ -40,7 +40,7 @@ async def test_websocket_connection(websocket_url: str) -> tuple[bool, str]:
         websocket_url (str): WebSocket服务器的URL。
 
     Returns:
-        tuple[bool, str]: 
+        tuple[bool, str]:
             - 第一个值为布尔值，表示连接是否成功。
             - 第二个值为字符串，包含状态消息。
 


### PR DESCRIPTION
- 重构验证函数：拆分格式验证和连接测试
- 移除强制连接验证：连接失败时显示警告而不阻止添加
- 改进错误提示：明确指出可能需要配置认证header
- 保持现有功能：header管理和连接时header使用不变

这样用户可以先添加需要认证的服务器，然后配置认证header