### PR TITLE
fix(minecraft): 修复update命令MessageChain参数绑定错误

### DIFF
--- a/modules/self_contained/minicraft_info/__init__.py
+++ b/modules/self_contained/minicraft_info/__init__.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 from core.control import Distribute, FrequencyLimitation, Function, Permission
 from core.models import saya_model
+from utils.type import parse_match_type
 
 # 导入数据库模型以确保表被创建
 # 导入数据库操作函数
@@ -401,10 +402,10 @@ async def mcadmin_update_server(
             await app.send_message(group, MessageChain(help_message), quote=source)
             return
 
-        # 解析参数
-        new_name = name.result if name.matched else None
-        new_address = address.result if address.matched else None
-        new_websocket_url = websocket.result if websocket.matched else None
+        # 解析参数 - 使用 parse_match_type 正确处理 MessageChain 对象
+        new_name = parse_match_type(name, str, None)
+        new_address = parse_match_type(address, str, None)
+        new_websocket_url = parse_match_type(websocket, str, None)
 
         # 检查是否至少指定了一个更新参数
         if not any([new_name, new_address, new_websocket_url]):

--- a/tests/test_minecraft_update_fix.py
+++ b/tests/test_minecraft_update_fix.py
@@ -1,0 +1,152 @@
+"""
+pytest测试文件：Minecraft 服务器管理模块参数解析修复验证
+
+测试覆盖范围：
+1. parse_match_type 函数处理 MessageChain 对象的各种场景
+2. 数据库参数绑定类型安全性验证
+3. 用户实际使用的命令格式兼容性测试
+
+修复问题：解决 /mcadmin update 命令中 MessageChain 对象被错误传递给数据库导致的
+"type 'MessageChain' is not supported" 和 "'MessageChain' object has no attribute 'decode'" 错误
+
+运行方式：
+- 运行所有测试：uv run pytest tests/test_minecraft_update_fix.py
+- 运行详细输出：uv run pytest tests/test_minecraft_update_fix.py -v
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+# 添加项目根目录到路径
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from graia.ariadne.message.chain import MessageChain
+from graia.ariadne.message.element import Plain
+from graia.ariadne.message.parser.twilight import ArgResult
+
+from utils.type import parse_match_type
+
+
+class TestMinecraftParameterParsing:
+    """Minecraft 服务器管理模块参数解析修复的pytest测试类"""
+
+    def test_parse_match_type_with_message_chain(self):
+        """测试 parse_match_type 能正确处理 MessageChain 对象"""
+        # 模拟 ArgResult 对象，其中 result 是 MessageChain
+        mock_arg_result = Mock(spec=ArgResult)
+        mock_arg_result.matched = True
+        mock_arg_result.result = MessageChain([Plain(text="13的香草纪元")])
+
+        # 使用 parse_match_type 解析
+        result = parse_match_type(mock_arg_result, str, None)
+
+        # 验证结果是纯字符串
+        assert result == "13的香草纪元"
+        assert isinstance(result, str)
+
+    def test_parse_match_type_with_string(self):
+        """测试 parse_match_type 能正确处理字符串对象"""
+        # 模拟 ArgResult 对象，其中 result 是字符串
+        mock_arg_result = Mock(spec=ArgResult)
+        mock_arg_result.matched = True
+        mock_arg_result.result = "测试服务器"
+
+        # 使用 parse_match_type 解析
+        result = parse_match_type(mock_arg_result, str, None)
+
+        # 验证结果是纯字符串
+        assert result == "测试服务器"
+        assert isinstance(result, str)
+
+    def test_parse_match_type_not_matched(self):
+        """测试 parse_match_type 在参数未匹配时返回默认值"""
+        # 模拟 ArgResult 对象，未匹配
+        mock_arg_result = Mock(spec=ArgResult)
+        mock_arg_result.matched = False
+
+        # 使用 parse_match_type 解析
+        result = parse_match_type(mock_arg_result, str, None)
+
+        # 验证返回默认值
+        assert result is None
+
+    def test_parse_match_type_with_complex_message_chain(self):
+        """测试 parse_match_type 能正确处理复杂的 MessageChain 对象"""
+        # 模拟包含多个元素的 MessageChain
+        mock_arg_result = Mock(spec=ArgResult)
+        mock_arg_result.matched = True
+        mock_arg_result.result = MessageChain(
+            [Plain(text="服务器名称: "), Plain(text="我的世界服务器")]
+        )
+
+        # 使用 parse_match_type 解析
+        result = parse_match_type(mock_arg_result, str, None)
+
+        # 验证结果是合并后的纯字符串
+        assert result == "服务器名称: 我的世界服务器"
+        assert isinstance(result, str)
+
+    def test_database_parameter_binding_simulation(self):
+        """模拟数据库参数绑定场景，确保不会出现 MessageChain 类型错误"""
+        # 模拟从命令解析得到的参数
+        name_arg = Mock(spec=ArgResult)
+        name_arg.matched = True
+        name_arg.result = MessageChain([Plain(text="13的香草纪元")])
+
+        address_arg = Mock(spec=ArgResult)
+        address_arg.matched = True
+        address_arg.result = MessageChain([Plain(text="mc.example.com:25565")])
+
+        websocket_arg = Mock(spec=ArgResult)
+        websocket_arg.matched = False
+
+        # 使用修复后的解析方式
+        new_name = parse_match_type(name_arg, str, None)
+        new_address = parse_match_type(address_arg, str, None)
+        new_websocket_url = parse_match_type(websocket_arg, str, None)
+
+        # 验证所有参数都是正确的类型
+        assert isinstance(new_name, str)
+        assert new_name == "13的香草纪元"
+
+        assert isinstance(new_address, str)
+        assert new_address == "mc.example.com:25565"
+
+        assert new_websocket_url is None
+
+        # 模拟数据库操作 - 这些参数现在可以安全地传递给数据库
+        # 不会出现 "type 'MessageChain' is not supported" 错误
+        db_params = [new_name, new_address, new_websocket_url]
+        for param in db_params:
+            if param is not None:
+                assert isinstance(param, str), f"参数 {param} 不是字符串类型"
+
+    def test_websocket_url_with_equals_sign(self):
+        """测试带等号的 WebSocket URL 参数解析（模拟用户实际使用的命令）"""
+        # 模拟用户使用 --websocket=ws://example.com:8080 的情况
+        websocket_arg = Mock(spec=ArgResult)
+        websocket_arg.matched = True
+        websocket_arg.result = MessageChain([Plain(text="ws://example.com:8080")])
+
+        # 使用修复后的解析方式
+        new_websocket_url = parse_match_type(websocket_arg, str, None)
+
+        # 验证结果是正确的字符串
+        assert isinstance(new_websocket_url, str)
+        assert new_websocket_url == "ws://example.com:8080"
+
+        # 验证 URL 格式正确（可以被 urlparse 解析）
+        from urllib.parse import urlparse
+
+        parsed = urlparse(new_websocket_url)
+        assert parsed.scheme == "ws"
+        assert parsed.hostname == "example.com"
+        assert parsed.port == 8080
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 🐛 问题描述

修复 `/mcadmin update` 命令中 MessageChain 对象被错误传递给数据库导致的参数绑定错误。

**错误信息：**
- `Error binding parameter 1: type 'MessageChain' is not supported`
- `'MessageChain' object has no attribute 'decode'`

**触发场景：**
用户使用 `/mcadmin update 3 --websocket=ws://example.com:8080` 等命令时出现错误。

## 🔧 修复内容

### 主要修改
- **文件：** `modules/self_contained/minicraft_info/__init__.py`
- **修复：** 使用 `parse_match_type` 工具函数正确处理 `ArgResult` 参数解析
- **影响：** `--name`、`--address`、`--websocket` 参数现在能正确处理 MessageChain 对象

### 修复前后对比
```python
# 修复前（有问题）
new_name = name.result if name.matched else None
new_address = address.result if address.matched else None  
new_websocket_url = websocket.result if websocket.matched else None

# 修复后（正确）
new_name = parse_match_type(name, str, None)
new_address = parse_match_type(address, str, None)
new_websocket_url = parse_match_type(websocket, str, None)
```

## ✅ 测试验证

### 新增测试文件
- **文件：** `tests/test_minecraft_update_fix.py`
- **覆盖：** 6个测试用例，涵盖所有关键场景
- **验证：** MessageChain 处理、字符串处理、未匹配参数、复杂场景

### 测试结果
```bash
$ uv run pytest tests/test_minecraft_update_fix.py -v
======================== 6 passed ========================
```

## 🎯 修复效果

现在支持以下命令格式：
```bash
# 带等号格式
/mcadmin update 3 --websocket=ws://example.com:8080

# 空格格式  
/mcadmin update 3 --websocket ws://example.com:8080

# 短参数格式
/mcadmin update 3 -w ws://example.com:8080

# 组合更新
/mcadmin update 3 --name 新服务器名 --websocket ws://example.com:8080
```

## 📋 变更清单

- [x] 修复 MessageChain 参数解析问题
- [x] 添加 `parse_match_type` 工具函数导入
- [x] 创建完整的回归测试
- [x] 验证所有测试通过
- [x] 确保代码符合项目规范（通过 ruff 检查）

## 🔍 影响范围

- **模块：** Minecraft 服务器管理
- **命令：** `/mcadmin update`
- **参数：** `--name`、`--address`、`--websocket`
- **兼容性：** 向后兼容，不影响现有功能

## 🚀 部署说明

此修复可以安全部署，不需要数据库迁移或配置更改。修复后用户可以正常使用 `/mcadmin update` 命令更新服务器配置。

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author