### PR TITLE
fix(bf1): resolve SSL certificate error and null pointer exception

### DIFF
--- a/modules/self_contained/bf1_info/__init__.py
+++ b/modules/self_contained/bf1_info/__init__.py
@@ -111,6 +111,11 @@ async def check_default_account(app: Ariadne):
         )
     # 登录默认账号
     account_instance = await BF1DA.get_api_instance()
+    if account_instance is None:
+        logger.error("获取默认账号实例失败，请检查默认账号配置")
+        return await app.send_friend_message(
+            config.Master, MessageChain("BF1默认账号配置错误，请检查配置!")
+        )
     await account_instance.login(account_instance.remid, account_instance.sid)
     # 更新默认账号信息
     if account_info := await BF1DA.update_player_info():

--- a/utils/bf1/gateway_api.py
+++ b/utils/bf1/gateway_api.py
@@ -220,7 +220,15 @@ class bf1_api:
             },
         }
         self.auto_login_count = 0
-        self.http_session = aiohttp.ClientSession()
+        # 创建SSL上下文，禁用证书验证以解决526错误
+        import ssl
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
+        connector = aiohttp.TCPConnector(ssl=ssl_context)
+        self.http_session = aiohttp.ClientSession(connector=connector)
 
     # api调用
     async def check_session_expire(self) -> bool:
@@ -363,7 +371,7 @@ class bf1_api:
             "X-Origin-Platform": "PCWIN",
         }
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=False) as client:
                 response2 = await client.get(url2, headers=header2)
             authcode = response2.headers["location"]
             authcode = authcode[authcode.rfind("=") + 1 :]


### PR DESCRIPTION
- Disable SSL verification for EA API requests to fix 526 error
- Add null check for default account instance to prevent AttributeError
- Configure aiohttp and httpx clients with proper SSL settings
