### PR TITLE
修复 QQ 新版图片协议下 random_wife 添加图片路径异常

### DIFF
--- a/modules/self_contained/random_wife/__init__.py
+++ b/modules/self_contained/random_wife/__init__.py
@@ -100,7 +100,10 @@ async def add_wife_handle(
     img: Image = img.result
     img_url = img.url
     img_name = wife_name.result.display.replace("\n", "")
-    img_type = img.dict()["imageId"][img.dict()["imageId"].rfind(".") + 1 :]
+    image_id = img.dict().get("imageId", "")
+    valid_extensions = {"jpg", "jpeg", "png", "gif", "bmp", "webp"}
+    ext_candidate = image_id.rsplit(".", 1)[-1].lower() if "." in image_id else ""
+    img_type = ext_candidate if ext_candidate in valid_extensions else "png"
     if img_name in ["\n", ""]:
         return await app.send_message(group, MessageChain("请输入名字!"), quote=source)
     path = Path(__file__).parent / "wife"


### PR DESCRIPTION
@
## Summary

- QQ 新版协议中 `imageId` 不再是 `{xxx}.jpg` 格式，而是完整 URL（如 `gchat.qpic.cn/download?appid=...`）
- 原有的 `rfind(".")` 提取扩展名会匹配到域名中的点，生成 `.cn\download?...` 这样的非法路径
- 改为校验提取结果是否属于合法图片扩展名集合，不合法时回退到 `png`

## Test plan

- [ ] 使用 `-添加wife` 命令添加图片，确认文件正确保存为 `.png` 格式
- [ ] 确认旧协议格式的 imageId（如 `{xxx}.jpg`）仍能正确提取扩展名
@