### PR TITLE
Fix -viplist/-vbanlist double reply (vip command prefix collision)

### DIFF
--- a/modules/self_contained/bf1_servermanager/__init__.py
+++ b/modules/self_contained/bf1_servermanager/__init__.py
@@ -6829,17 +6829,11 @@ async def add_vip(
 ):
     if bf_group_name.matched and bf_group_name.result.display in ["ban", "b", "ba"]:
         return
-    if server_rank.matched and server_rank.result.display in [
-        "iplis",
-        "lis",
-        "ip列",
-        "l",
-        "列",
-        "ban",
-        "b",
-        "ba",
-    ]:
-        logger.debug(server_rank)
+    # -vip/-v 是 -viplist/-vbanlist/-vl/-vban 等命令的前缀，UnionMatch 会把这些更长的
+    # 命令误匹配进来。实测这类误触发后 server_rank 必为非数字残留(例如 -viplist 6 会被
+    # 解析成 server_rank='t')，而真正的加 vip 指令 server_rank 必为数字序号。因此非数字
+    # 一律静默返回，交由对应的专用监听器处理，避免一条命令出现两条回复。
+    if not server_rank.result.display.isdigit():
         return
 
     # 日期检查


### PR DESCRIPTION
## 问题

`-viplist 6` 会触发两条回复：一条来自 `add_vip` 的误报 `请输入正确的服务器序号`，一条来自 `get_vipList` 的正确列表。

## 根因

`add_vip` 监听器的 `UnionMatch("-vip", "-v", ...)` 中，`-vip`/`-v` 是 `-viplist`/`-vbanlist`/`-vl`/`-vban` 等更长命令的前缀，导致同一条消息被两个监听器同时匹配。

原有的 `server_rank` 词黑名单（`"lis"`、`"ban"` 等）从未生效：`bf_group_name` 贪婪匹配吃掉了残留词的大部分，`server_rank` 只拿到最后一个字符。实测 `-viplist 6` 解析为 `bf_group_name='lis'`、`server_rank='t'`、`player_name='6'`，黑名单里的整词 `"list"` 与实际值 `'t'` 永远对不上。

## 修复

改用稳健不变量：真正的加 vip 命令 `server_rank` 必为数字序号。所有前缀碰撞解析出的 `server_rank` 都是非数字（已对 `-viplist`/`-vbanlist`/`-vl`/`-vban` 的空格式与 `#` 式逐一实测确认），因此非数字一律静默返回，交给对应的专用监听器处理。该方案无需枚举，自动覆盖现有及未来所有 `-vXxx` 前缀命令。

## 实测验证

| 命令 | 修复后 add_vip 行为 |
|------|---------------------|
| `-viplist 6` / `-vip列表 6` / `-vbanlist 6` / `-vban列表 6` / `-vl 6` / `-vb 6` / `-vban 6` | 静默，不发回复 |
| `-viplist#1` 等 `#` 式 | 本就 NO MATCH，不触发 |
| `-vip 1 player 7` / `-vip1 player 7` / `-vipsakula#1 player 7` / `-vip#2 player` | 正常进入处理流程 |

## Test plan

- [x] py_compile + ruff check 通过
- [x] Twilight 解析实测：碰撞命令全部静默，合法命令全部放行
- [ ] 部署后实测 `-viplist 6` 只返回一条 vip 列表