### PR TITLE
Fix VIP add when EA has multiple accounts sharing one display name

### DIFF
--- a/modules/self_contained/bf1_servermanager/__init__.py
+++ b/modules/self_contained/bf1_servermanager/__init__.py
@@ -65,6 +65,7 @@ from utils.bf1.bf_utils import (
 from utils.bf1.data_handle import VehicleData, WeaponData
 from utils.bf1.database import BF1DB
 from utils.bf1.default_account import BF1DA
+from utils.bf1.gateway_api import EA_ERR_PLAYER_NOT_FOUND
 from utils.bf1.draw import (
     PlayerStatPic,
     PlayerVehiclePic,
@@ -7662,7 +7663,9 @@ async def check_vip(
                 # EA 明确回 -32856(玩家不存在)，说明数据库挂着一条同名空号脏记录。
                 # 留着每轮 checkvip 都会重试+刷错误日志，无法自愈，直接清掉。
                 # 仅匹配 EA 定义的玩家级错误，不误删会话失效等可恢复错误。
-                if add_task_result[i] == "玩家不存在":
+                # 注意：极少数情况下 -32856 可能是 EA 临时抽风(账号短期被锁等)，
+                # 自愈后该玩家会丢 VIP；用 warning 让运维看见，必要时人工补回。
+                if add_task_result[i] == EA_ERR_PLAYER_NOT_FOUND:
                     await BF1ServerVipManager.del_server_vip_by_pid(
                         server_id=server_id,
                         player_pid=add_task[i]["personaId"],
@@ -7676,6 +7679,11 @@ async def check_vip(
                         display_name=add_task[i]["displayName"],
                         action="unvip",
                         info="自动清理(玩家不存在)",
+                    )
+                    logger.warning(
+                        f"checkvip 自愈：删除脏 VIP 记录 server={server_id} "
+                        f"pid={add_task[i]['personaId']} name={add_task[i]['displayName']} "
+                        f"(EA 报玩家不存在；若为短期 EA 抽风请人工补回)"
                     )
         send = [
             f"操作完成!\n成功添加{add_suc_count}个,失败{add_fail_count}个\n成功删除{del_suc_count}个,失败{del_fail_count}个"

--- a/modules/self_contained/bf1_servermanager/__init__.py
+++ b/modules/self_contained/bf1_servermanager/__init__.py
@@ -7659,6 +7659,24 @@ async def check_vip(
             else:
                 add_task[i]["result"] = f"添加失败!{add_task_result[i]}"
                 add_fail_count += 1
+                # EA 明确回 -32856(玩家不存在)，说明数据库挂着一条同名空号脏记录。
+                # 留着每轮 checkvip 都会重试+刷错误日志，无法自愈，直接清掉。
+                # 仅匹配 EA 定义的玩家级错误，不误删会话失效等可恢复错误。
+                if add_task_result[i] == "玩家不存在":
+                    await BF1ServerVipManager.del_server_vip_by_pid(
+                        server_id=server_id,
+                        player_pid=add_task[i]["personaId"],
+                    )
+                    await BF1Log.record(
+                        operator_qq=sender.id,
+                        serverId=server_id,
+                        persistedGameId=server_guid,
+                        gameId=server_gameid,
+                        pid=add_task[i]["personaId"],
+                        display_name=add_task[i]["displayName"],
+                        action="unvip",
+                        info="自动清理(玩家不存在)",
+                    )
         send = [
             f"操作完成!\n成功添加{add_suc_count}个,失败{add_fail_count}个\n成功删除{del_suc_count}个,失败{del_fail_count}个"
         ]

--- a/tests/test_persona_picker.py
+++ b/tests/test_persona_picker.py
@@ -1,0 +1,88 @@
+"""_pick_bf1_persona 同名多账号消歧测试
+
+回归保护：EA 允许多账号共用同一 displayName(本次事故中 "Sipne" 同时落到真号
+1008491571150 和不玩 BF1 的空号 1004344969376)，原实现盲取 candidates[0] 把
+空号写进 vip 表，导致 -checkvip 永远 -32856 玩家不存在。修复要求按 BF1 生涯
+时长 timePlayed 区分真号。
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+bf_utils = pytest.importorskip(
+    "utils.bf1.bf_utils",
+    reason="bf_utils 依赖未装齐(uv sync 后再跑)",
+)
+
+
+class _FakeApi:
+    """detailedStatsByPersonaId 的最小桩，按 pid 查表回填 timePlayed"""
+
+    def __init__(self, times: dict[str, int]):
+        self._times = times
+
+    async def detailedStatsByPersonaId(self, pid):
+        return {"result": {"basicStats": {"timePlayed": self._times.get(str(pid), 0)}}}
+
+
+class _FakeBF1DA:
+    api: _FakeApi | None = None
+
+    @classmethod
+    async def get_api_instance(cls):
+        return cls.api
+
+
+def test_single_candidate_skips_api(monkeypatch):
+    """单候选不应调用 EA 接口(零开销路径)"""
+    sentinel = _FakeApi({})
+
+    async def _boom():
+        raise AssertionError("不该被调到")
+
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = sentinel
+    sentinel.detailedStatsByPersonaId = lambda pid: _boom()  # type: ignore[assignment]
+
+    only = {"personaId": 42, "displayName": "X"}
+    assert asyncio.run(bf_utils._pick_bf1_persona([only])) is only
+
+
+def test_multi_candidate_picks_player_with_playtime(monkeypatch):
+    """同名多账号必须挑出 timePlayed > 0 的真号(本次事故的核心回归点)"""
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = _FakeApi(
+        {"1008491571150": 3_257_572, "1004344969376": 0}  # 904h vs 0
+    )
+    void = {"personaId": 1004344969376, "displayName": "Sipne"}
+    real = {"personaId": 1008491571150, "displayName": "Sipne"}
+    chosen = asyncio.run(bf_utils._pick_bf1_persona([void, real]))
+    assert chosen is real, "应当挑出有 BF1 生涯时长的真号"
+
+
+def test_multi_candidate_all_zero_returns_first(monkeypatch):
+    """全 0 / 全无生涯时退回首个，保持解析不阻断"""
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = _FakeApi({})
+    a = {"personaId": 1, "displayName": "X"}
+    b = {"personaId": 2, "displayName": "X"}
+    assert asyncio.run(bf_utils._pick_bf1_persona([a, b])) is a
+
+
+def test_multi_candidate_api_error_falls_back_to_first(monkeypatch):
+    """EA 抽风时不阻断(异常→视作 0→退回首个)"""
+
+    class _BrokenApi:
+        async def detailedStatsByPersonaId(self, pid):
+            raise RuntimeError("EA down")
+
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = _BrokenApi()  # type: ignore[assignment]
+    a = {"personaId": 1, "displayName": "X"}
+    b = {"personaId": 2, "displayName": "X"}
+    assert asyncio.run(bf_utils._pick_bf1_persona([a, b])) is a

--- a/utils/bf1/bf_utils.py
+++ b/utils/bf1/bf_utils.py
@@ -124,6 +124,33 @@ async def _get_pid_by_name_via_gametools(player_name: str) -> int | None:
         return None
 
 
+async def _pick_bf1_persona(candidates: list[dict]) -> dict:
+    """同名 displayName 多个精确候选时，按 BF1 生涯时长选真号。
+
+    EA 允许多个账号共用同一 displayName，SearchPlayer 也不保证精确候选的顺序，
+    盲取 candidates[0] 会把不玩 BF1 的同名空号写进 vip/绑定表，下游 addServerVip
+    必然报「玩家不存在」。这里用 detailedStatsByPersonaId 的 basicStats.timePlayed
+    区分：真正玩过 BF1 的账号 > 0，空号是 0 或接口直接报错。单候选 / 全 0 / 全
+    报错时退回首个候选，保证不阻断解析。
+    """
+    if len(candidates) <= 1:
+        return candidates[0]
+    api = await BF1DA.get_api_instance()
+
+    async def _playtime(pid) -> int:
+        try:
+            data = await api.detailedStatsByPersonaId(pid)
+        except Exception:
+            return 0
+        if not isinstance(data, dict):
+            return 0
+        return (data.get("result") or {}).get("basicStats", {}).get("timePlayed") or 0
+
+    times = await asyncio.gather(*[_playtime(c["personaId"]) for c in candidates])
+    best_idx = max(range(len(candidates)), key=lambda i: times[i])
+    return candidates[best_idx] if times[best_idx] > 0 else candidates[0]
+
+
 async def get_personas_by_name(player_name: str) -> dict | str | None:
     """根据玩家名称精确获取玩家信息
 
@@ -155,7 +182,10 @@ async def get_personas_by_name(player_name: str) -> dict | str | None:
         if str(persona.get("displayName", "")).casefold() == target_name
     ]
     if exact:
-        hit = exact[0]
+        # EA 允许同名多账号，按 BF1 生涯时长选真号；调用方统一读 persona[0]，
+        # 选中的需置首，否则 vip/bind/ban 全链路依旧会落到空号上。
+        hit = await _pick_bf1_persona(exact)
+        exact = [hit] + [p for p in exact if p is not hit]
         # 写入数据库
         try:
             await BF1DB.bf1account.update_bf1account(

--- a/utils/bf1/gateway_api.py
+++ b/utils/bf1/gateway_api.py
@@ -14,6 +14,10 @@ from core.config import GlobalConfig
 config = create(GlobalConfig)
 proxy = config.proxy if config.proxy != "proxy" else ""
 
+# 暴露的 EA 错误常量：消费方匹配错误时引用本常量，避免硬编码翻译串
+# 一处变更全链路同步(error_code_dict 也引用同一常量)。
+EA_ERR_PLAYER_NOT_FOUND = "玩家不存在"
+
 
 async def get_a_uuid() -> str:
     """返回一个uuid"""
@@ -66,7 +70,7 @@ class bf1_api:
             -32603: "此code为多个错误共用,请查阅error_msg_dict",
             # -32850: "服务器栏位已满/玩家已在栏位",
             -32851: "服务器不存在/已过期",
-            -32856: "玩家不存在",
+            -32856: EA_ERR_PLAYER_NOT_FOUND,
             -32857: "无法处置管理员",
             -32858: "服务器未开启",
         }


### PR DESCRIPTION
## 问题

线上事故：玩家 `Sipne` 能查询、能 `-vip` 加（提示成功），但 `-checkvip` 永远报 `addServerVip` 失败「玩家不存在」(`-32856`)，且每轮 checkvip 都重试刷错。

## 根因

`get_personas_by_name` 第一层：

```python
exact = [p for p in personas if p.displayName.casefold() == target]
if exact:
    hit = exact[0]   # ← bug
```

EA 允许多个账号共用同一 displayName，`SearchPlayer` 对 `Sipne` 同时返回真号 `1008491571150`（904h 生涯）和不玩 BF1 的空号 `1004344969376`，顺序不固定。盲取 `exact[0]` 把空号写进 vip 表，所有按名字的命令（vip/bind/ban/stat）取 `persona[0]` 全部落到空号上，`addServerVip` 自然永远拒。

`-stat` 偶尔“能查”是另一条路径走运（缓存兜底碰巧选中真号 + 战绩接口对空号也返回结构化 0 数据），不能证明账号真实玩过 BF1。

## 修复

### 1. 治本 — `utils/bf1/bf_utils.py`

新增 `_pick_bf1_persona(candidates)`：多候选时并发查 `detailedStatsByPersonaId`，按 `basicStats.timePlayed` 选真号（真玩家必 >0，空号 0 或接口报错）；选中置首，下游 `persona[0]` 拿到的就是真号。

- 单候选：直接返回，零额外开销
- 全 0 / API 异常：退回首个候选，保证不阻断解析
- 受益面：vip、bind、ban、stat 全链路

### 2. 兜底 — `modules/self_contained/bf1_servermanager/__init__.py` `check_vip`

`addServerVip` 返回 `\"玩家不存在\"` 时自动删 DB 记录并写日志。让历史脏号 / 漏网错号能自愈，不再每轮刷错。仅匹配 EA 明确的玩家级错误（-32856），不误删会话失效等可恢复错误。

### 3. 回归测试 — `tests/test_persona_picker.py`

4 个用例：
- 单候选不调 EA 接口
- 多候选选真号（用事故的真实 pid `1008491571150` + 真实时长 904h vs 空号 0）
- 全 0 退回首个
- API 异常退回首个

## 测试

- `uv run pytest tests/test_persona_picker.py -v` → **4 passed**
- `uv run ruff check` → **All checks passed**（pre-commit hook 自动通过）

## 运维 follow-up

历史脏记录手动清一次（或等下次 checkvip 由本 PR 的自愈逻辑自动删）：

\`\`\`
-减v 2 #1004344969376
\`\`\`

## Test plan

- [x] 单元测试覆盖 picker 全部分支
- [ ] 部署后实际执行 \`-减v 2 #1004344969376\` 清理脏记录（或观察自愈日志）
- [ ] 实际执行 \`-vip 2 Sipne <天数>\` 验证不再落到空号
- [ ] \`-checkvip 2\` 不再出现 \`玩家不存在\` 错误日志