### PR TITLE
Reject non-BF1 player in name-based server-management ops

### DIFF
--- a/modules/self_contained/bf1_servermanager/__init__.py
+++ b/modules/self_contained/bf1_servermanager/__init__.py
@@ -3318,7 +3318,7 @@ async def kick(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -4019,7 +4019,7 @@ async def add_ban(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -4188,7 +4188,7 @@ async def del_ban(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -4374,7 +4374,7 @@ async def add_banall(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -4576,7 +4576,7 @@ async def del_banall(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -5106,7 +5106,7 @@ async def add_cloudban(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -5276,7 +5276,7 @@ async def del_cloudban(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -6106,7 +6106,7 @@ async def move_player(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -6930,7 +6930,7 @@ async def add_vip(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source
@@ -7285,7 +7285,7 @@ async def del_vip(
         dict_temp = {"personas": {"persona": [player_info["result"][str(player_pid)]]}}
         player_info = dict_temp
     else:
-        player_info = await get_personas_by_name(player_name)
+        player_info = await get_personas_by_name(player_name, require_bf1_player=True)
     if isinstance(player_info, str):
         return await app.send_message(
             group, MessageChain(f"查询出错!{player_info}"), quote=source

--- a/tests/test_persona_picker.py
+++ b/tests/test_persona_picker.py
@@ -86,3 +86,36 @@ def test_multi_candidate_api_error_falls_back_to_first(monkeypatch):
     a = {"personaId": 1, "displayName": "X"}
     b = {"personaId": 2, "displayName": "X"}
     assert asyncio.run(bf_utils._pick_bf1_persona([a, b])) is a
+
+
+# ---- _gate_bf1_player：服管路径"非 BF1 玩家"硬拦截 ----
+
+
+def _dict_for(pid: int, name: str = "Sipne") -> dict:
+    return {"personas": {"persona": [{"personaId": pid, "displayName": name}]}}
+
+
+def test_gate_off_returns_dict_unchanged(monkeypatch):
+    """require_bf1_player=False 时直接放行，不调 API"""
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = _FakeApi({})
+    d = _dict_for(1004344969376)
+    assert asyncio.run(bf_utils._gate_bf1_player("Sipne", d, False)) is d
+
+
+def test_gate_on_rejects_zero_playtime(monkeypatch):
+    """空号(timePlayed=0) 必须被服管路径拦截，返回字符串而非 dict"""
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = _FakeApi({"1004344969376": 0})
+    d = _dict_for(1004344969376)
+    result = asyncio.run(bf_utils._gate_bf1_player("Sipne", d, True))
+    assert isinstance(result, str), "0 时长账号必须被拦"
+    assert "1004344969376" in result and "不是 BF1 玩家" in result
+
+
+def test_gate_on_passes_real_player(monkeypatch):
+    """真号(timePlayed>0) 放行返回原 dict"""
+    monkeypatch.setattr(bf_utils, "BF1DA", _FakeBF1DA)
+    _FakeBF1DA.api = _FakeApi({"1008491571150": 3_257_572})
+    d = _dict_for(1008491571150)
+    assert asyncio.run(bf_utils._gate_bf1_player("Sipne", d, True)) is d

--- a/utils/bf1/bf_utils.py
+++ b/utils/bf1/bf_utils.py
@@ -124,34 +124,58 @@ async def _get_pid_by_name_via_gametools(player_name: str) -> int | None:
         return None
 
 
+async def _get_bf1_playtime(pid: int | str) -> int:
+    """detailedStatsByPersonaId 抽出的 basicStats.timePlayed(秒)。
+
+    真玩过 BF1 必 > 0；空号 / 异常 / 接口报错统一返回 0，让上层把它视作
+    "不是 BF1 玩家"。
+    """
+    try:
+        api = await BF1DA.get_api_instance()
+        data = await api.detailedStatsByPersonaId(pid)
+    except Exception:
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    return (data.get("result") or {}).get("basicStats", {}).get("timePlayed") or 0
+
+
 async def _pick_bf1_persona(candidates: list[dict]) -> dict:
     """同名 displayName 多个精确候选时，按 BF1 生涯时长选真号。
 
     EA 允许多个账号共用同一 displayName，SearchPlayer 也不保证精确候选的顺序，
     盲取 candidates[0] 会把不玩 BF1 的同名空号写进 vip/绑定表，下游 addServerVip
-    必然报「玩家不存在」。这里用 detailedStatsByPersonaId 的 basicStats.timePlayed
-    区分：真正玩过 BF1 的账号 > 0，空号是 0 或接口直接报错。单候选 / 全 0 / 全
-    报错时退回首个候选，保证不阻断解析。
+    必然报「玩家不存在」。这里按 timePlayed 区分：真号 > 0，空号是 0。单候选 /
+    全 0 / 全报错时退回首个候选，保证不阻断解析。
     """
     if len(candidates) <= 1:
         return candidates[0]
-    api = await BF1DA.get_api_instance()
-
-    async def _playtime(pid) -> int:
-        try:
-            data = await api.detailedStatsByPersonaId(pid)
-        except Exception:
-            return 0
-        if not isinstance(data, dict):
-            return 0
-        return (data.get("result") or {}).get("basicStats", {}).get("timePlayed") or 0
-
-    times = await asyncio.gather(*[_playtime(c["personaId"]) for c in candidates])
+    times = await asyncio.gather(
+        *[_get_bf1_playtime(c["personaId"]) for c in candidates]
+    )
     best_idx = max(range(len(candidates)), key=lambda i: times[i])
     return candidates[best_idx] if times[best_idx] > 0 else candidates[0]
 
 
-async def get_personas_by_name(player_name: str) -> dict | str | None:
+async def _gate_bf1_player(
+    player_name: str, persona_dict: dict, require_bf1_player: bool
+) -> dict | str:
+    """require_bf1_player=True 时，确认 persona_dict 命中的 pid 真玩 BF1。
+
+    返回原 dict (BF1 玩家) 或错误字符串 (非 BF1 玩家)。get_personas_by_name 所有
+    "返回 dict"分支统一过此关，避免服管命令落到不玩 BF1 的同名 EA 账号上。
+    """
+    if not require_bf1_player:
+        return persona_dict
+    pid = persona_dict["personas"]["persona"][0]["personaId"]
+    if await _get_bf1_playtime(pid) > 0:
+        return persona_dict
+    return f"玩家 {player_name}(pid {pid}) 不是 BF1 玩家(无游玩记录或账号不存在)"
+
+
+async def get_personas_by_name(
+    player_name: str, *, require_bf1_player: bool = False
+) -> dict | str | None:
     """根据玩家名称精确获取玩家信息
 
     EA 的 SearchPlayer 是模糊前缀搜索，返回的候选列表既不保证精确项排在首位，
@@ -169,6 +193,9 @@ async def get_personas_by_name(player_name: str) -> dict | str | None:
       由调用方统一加"查询出错!"前缀展示）。
 
     :param player_name: 玩家名称
+    :param require_bf1_player: True 时仅返回真 BF1 玩家(timePlayed>0)；非真玩家
+        返回错误字符串。供服管类操作(vip/ban/kick/move 等)使用，避免对不玩 BF1
+        的同名 EA 账号执行实质动作。-stat 等查询路径保持默认 False。
     :return: 精确命中返回dict，未精确命中返回str提示，无任何候选返回None
     """
     player_info = await (await BF1DA.get_api_instance()).getPersonasByName(player_name)
@@ -196,23 +223,29 @@ async def get_personas_by_name(player_name: str) -> dict | str | None:
             )
         except Exception as e:
             logger.error((e, player_info))
-        return {"personas": {"persona": exact}}
+        return await _gate_bf1_player(
+            player_name, {"personas": {"persona": exact}}, require_bf1_player
+        )
     # SearchPlayer 没有精确命中，回退查本地缓存(支持连字符玩家名)
     cached = await BF1DB.bf1account.get_bf1account_by_displayName(player_name)
     if cached and cached.get("pid"):
         display_name = cached.get("displayName") or player_name
-        return {
-            "personas": {
-                "persona": [
-                    {
-                        "personaId": cached["pid"],
-                        "pidId": cached.get("uid"),
-                        "displayName": display_name,
-                        "name": cached.get("name") or str(display_name).lower(),
-                    }
-                ]
-            }
-        }
+        return await _gate_bf1_player(
+            player_name,
+            {
+                "personas": {
+                    "persona": [
+                        {
+                            "personaId": cached["pid"],
+                            "pidId": cached.get("uid"),
+                            "displayName": display_name,
+                            "name": cached.get("name") or str(display_name).lower(),
+                        }
+                    ]
+                }
+            },
+            require_bf1_player,
+        )
     # SearchPlayer 与本地缓存都落空，用 gametools 把名字翻译成 pid 后回 EA 原生取数据
     gametools_pid = await _get_pid_by_name_via_gametools(player_name)
     if gametools_pid:
@@ -225,18 +258,22 @@ async def get_personas_by_name(player_name: str) -> dict | str | None:
                 # 仅接受 gametools 翻译结果与查询名忽略大小写一致的精确命中，
                 # 防止 gametools 历史名变更或误匹配返回到错误玩家
                 if str(display_name).casefold() == target_name:
-                    return {
-                        "personas": {
-                            "persona": [
-                                {
-                                    "personaId": gametools_pid,
-                                    "pidId": ea_persona.get("nucleusId"),
-                                    "displayName": display_name,
-                                    "name": str(display_name).lower(),
-                                }
-                            ]
-                        }
-                    }
+                    return await _gate_bf1_player(
+                        player_name,
+                        {
+                            "personas": {
+                                "persona": [
+                                    {
+                                        "personaId": gametools_pid,
+                                        "pidId": ea_persona.get("nucleusId"),
+                                        "displayName": display_name,
+                                        "name": str(display_name).lower(),
+                                    }
+                                ]
+                            }
+                        },
+                        require_bf1_player,
+                    )
     if not personas:
         return None
     # 把近似玩家名反馈给使用者，便于用正确的名字重新查询


### PR DESCRIPTION
## 背景

承接 #198。#198 解决了"同名多候选时按 timePlayed 选真号"，但留了一个洞：当 SearchPlayer 对一个名字**只返回单个空号候选**时（真号改名/被吞/对名字索引不到），picker 直接信任、把空号写库。行动服加 v 不立即调 EA → 不报错 → 直到下一次 `-checkvip` 才被 PR #198 的自愈分支清掉，期间真玩家从未拿到 VIP。

本 PR 直接堵死服管类路径对非 BF1 玩家的入口：名字解析不到真 BF1 玩家就不让进。

## 设计

| 路径 | 行为 |
|---|---|
| 服管类（vip/ban/kick/move 等 10 个命令） | 名字解析强制要求 `timePlayed > 0`，否则返回 `玩家 X(pid Y) 不是 BF1 玩家` |
| 查询类（-stat / -list / 等 9 个 bf1_info 命令） | 不变。0 时长账号仍可查空白战绩 |
| 跳过 | `managerAccount_login`（绑定服管账号）、`check_ban`（查 BFEAC/BFBAN） |
| 已有保护 | `#<pid>` 路径走 `getPersonasByIds` 已有 EA 侧存在性校验，本 PR 不动 |

## 改动

**`utils/bf1/bf_utils.py`**
- 抽 `_get_bf1_playtime(pid)` 到模块级，`_pick_bf1_persona` 改用模块函数（去掉嵌套闭包）
- 新增 `_gate_bf1_player(name, dict, require)` 单一关卡。`get_personas_by_name` 所有"返回 dict"分支（精确 / 缓存 / gametools）统一过关
- `get_personas_by_name(*, require_bf1_player=False)` 加 kwarg

**`modules/self_contained/bf1_servermanager/__init__.py`**
- 10 处服管命令调用点改传 `require_bf1_player=True`：
  - `kick` / `add_ban` / `del_ban` / `add_banall` / `del_banall`
  - `add_cloudban` / `del_cloudban` / `move_player`
  - `add_vip` / `del_vip`
- 跳过 2 处：`managerAccount_login` / `check_ban`

**`tests/test_persona_picker.py`**
- 新增 3 个 gate 用例：require=False 直放、require=True 拦 0 时长、require=True 放真号（用事故的真实 pid 与时长）
- 原 4 个 picker 用例保持通过

## 测试

- `uv run pytest tests/test_persona_picker.py -v` → **7 passed**
- `uv run ruff check` → **All checks passed**
- pre-commit hook (ruff + ruff-format) → 通过

## 用户感受

- ✅ `-vip <真玩家>` 不受影响
- ✅ `-vip <空号同名>` 立即报"X 不是 BF1 玩家"，不再写库、不再等到 checkvip 自愈
- ✅ `-stat <0 小时账号>` 仍能出空白战绩图

## Test plan

- [x] 单元测试覆盖 gate 三种分支
- [ ] 重启 bot 后实测 `-vip 2 <某个不存在/非 BF1 名字>` 应立即被拒
- [ ] 实测 `-vip 2 <真玩家名>` 仍正常加 v
- [ ] 实测 `-stat <0 小时账号名>` 仍能查到（即便是空白战绩）